### PR TITLE
Add 'force' flag to rm to prevent hundreds of interactive prompts to …

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -12,7 +12,7 @@ mkdir "$TEMP_FOLDER/vtk-build"
 
 ( cd "$TEMP_FOLDER/vtk-build" && sudo make -j8 install)
 
-rm -r "$TEMP_FOLDER"
+rm -rf "$TEMP_FOLDER"
 
 echo 'export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:~/tarsim/lib:/usr/lib/include:/usr/local/lib' >> ~/.bashrc
 


### PR DESCRIPTION
When I ran setup.sh, it got stuck on the line that cleans up build files. It prompted me to delete every single one individually - which got old quickly.
```
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Modeling/CMakeFiles/vtkFiltersModeling.dir/vtkDijkstraImageGeodesicPath.cxx.o'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Modeling/CMakeFiles/vtkFiltersModeling.dir/vtkProjectedTexture.cxx.o'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Modeling/CMakeFiles/vtkFiltersModeling.dir/vtkSelectEnclosedPoints.cxx.o'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Modeling/CMakeFiles/vtkFiltersModeling.dir/vtkLinearSubdivisionFilter.cxx.o'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Modeling/CMakeFiles/vtkFiltersModeling.dir/vtkRotationalExtrusionFilter.cxx.o'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Modeling/CMakeFiles/vtkFiltersModeling.dir/vtkQuadRotationalExtrusionFilter.cxx.o'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Modeling/CMakeFiles/vtkFiltersModeling.dir/vtkDijkstraGraphGeodesicPath.cxx.o'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Modeling/CMakeFiles/vtkFiltersModeling.dir/CXX.includecache'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Modeling/CMakeFiles/vtkFiltersModeling.dir/vtkRuledSurfaceFilter.cxx.o'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Modeling/CMakeFiles/vtkFiltersModeling.dir/vtkSectorSource.cxx.o'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Modeling/CMakeFiles/vtkFiltersModeling.dir/vtkContourLoopExtraction.cxx.o'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Modeling/CMakeFiles/vtkFiltersModeling.dir/vtkGraphGeodesicPath.cxx.o'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Modeling/CMakeFiles/vtkFiltersModeling.dir/vtkPolyDataPointSampler.cxx.o'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Modeling/CMakeFiles/vtkFiltersModeling.dir/vtkGeodesicPath.cxx.o'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Modeling/CMakeFiles/vtkFiltersModeling.dir/vtkCookieCutter.cxx.o'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Modeling/CMakeFiles/vtkFiltersModeling.dir/vtkOutlineFilter.cxx.o'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Modeling/CMakeFiles/vtkFiltersModeling.dir/vtkAdaptiveSubdivisionFilter.cxx.o'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Modeling/CMakeFiles/vtkFiltersModeling.dir/vtkBandedPolyDataContourFilter.cxx.o'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Modeling/CMakeFiles/vtkFiltersModeling.dir/vtkVolumeOfRevolutionFilter.cxx.o'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Modeling/CMakeFiles/vtkFiltersModeling.dir/vtkSpherePuzzle.cxx.o'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Modeling/CMakeFiles/vtkFiltersModeling.dir/depend.internal'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Modeling/CMakeFiles/vtkFiltersModeling.dir/vtkButterflySubdivisionFilter.cxx.o'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Modeling/CMakeFiles/vtkFiltersModeling.dir/vtkRibbonFilter.cxx.o'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Modeling/CMakeFiles/vtkFiltersModeling.dir/vtkLoopSubdivisionFilter.cxx.o'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Modeling/CMakeFiles/vtkFiltersModeling.dir/vtkLinearExtrusionFilter.cxx.o'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Modeling/CMakeFiles/vtkFiltersModeling.dir/depend.make'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Modeling/CMakeFiles/vtkFiltersModeling.dir/vtkSpherePuzzleArrows.cxx.o'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Modeling/CMakeFiles/vtkFiltersModeling.dir/vtkSubdivideTetra.cxx.o'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Modeling/CMakeFiles/vtkFiltersModeling.dir/vtkFillHolesFilter.cxx.o'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Modeling/CMakeFiles/vtkFiltersModeling.dir/vtkSelectPolyData.cxx.o'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Hybrid/CMakeFiles/vtkFiltersHybrid.dir/vtkTemporalDataSetCache.cxx.o'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Hybrid/CMakeFiles/vtkFiltersHybrid.dir/vtkTemporalFractal.cxx.o'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Hybrid/CMakeFiles/vtkFiltersHybrid.dir/vtkTemporalInterpolator.cxx.o'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Hybrid/CMakeFiles/vtkFiltersHybrid.dir/vtkTemporalSnapToTimeStep.cxx.o'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Hybrid/CMakeFiles/vtkFiltersHybrid.dir/vtkAdaptiveDataSetSurfaceFilter.cxx.o'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Hybrid/CMakeFiles/vtkFiltersHybrid.dir/vtkImplicitModeller.cxx.o'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Hybrid/CMakeFiles/vtkFiltersHybrid.dir/vtkDSPFilterDefinition.cxx.o'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Hybrid/CMakeFiles/vtkFiltersHybrid.dir/vtkWeightedTransformFilter.cxx.o'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Hybrid/CMakeFiles/vtkFiltersHybrid.dir/CXX.includecache'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Hybrid/CMakeFiles/vtkFiltersHybrid.dir/vtkTransformToGrid.cxx.o'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Hybrid/CMakeFiles/vtkFiltersHybrid.dir/vtkTemporalShiftScale.cxx.o'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Hybrid/CMakeFiles/vtkFiltersHybrid.dir/vtkForceTime.cxx.o'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Hybrid/CMakeFiles/vtkFiltersHybrid.dir/vtkProjectedTerrainPath.cxx.o'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Hybrid/CMakeFiles/vtkFiltersHybrid.dir/vtkPCAAnalysisFilter.cxx.o'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Hybrid/CMakeFiles/vtkFiltersHybrid.dir/vtkRenderLargeImage.cxx.o'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Hybrid/CMakeFiles/vtkFiltersHybrid.dir/vtkBSplineTransform.cxx.o'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Hybrid/CMakeFiles/vtkFiltersHybrid.dir/vtkEarthSource.cxx.o'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Hybrid/CMakeFiles/vtkFiltersHybrid.dir/vtkImageToPolyDataFilter.cxx.o'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Hybrid/CMakeFiles/vtkFiltersHybrid.dir/vtkProcrustesAlignmentFilter.cxx.o'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Hybrid/CMakeFiles/vtkFiltersHybrid.dir/depend.internal'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Hybrid/CMakeFiles/vtkFiltersHybrid.dir/vtkDSPFilterGroup.cxx.o'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Hybrid/CMakeFiles/vtkFiltersHybrid.dir/vtkDepthSortPolyData.cxx.o'? y
rm: remove write-protected regular file '/tmp/install_eit/vtk-build/Filters/Hybrid/CMakeFiles/vtkFiltersHybrid.dir/vtkTemporalArrayOperatorFilter.cxx.o'? y
```

If you are worried about accidents, the "-I" flag will 
```
prompt once before removing more than three files, or
                          when removing recursively; less intrusive than -i,
                          while still giving protection against most mistakes
```

This change forces rm to remove the build files without needing a prompt. Branch was tested on Ubuntu 18.04.
